### PR TITLE
Fix persistence in DAO save method

### DIFF
--- a/src/main/java/com/empresa/fichajes/DaoImpl/FichajeDaoImpl.java
+++ b/src/main/java/com/empresa/fichajes/DaoImpl/FichajeDaoImpl.java
@@ -33,6 +33,11 @@ public class FichajeDaoImpl implements FichajeDao  {
 
     @Override
     public Fichaje save(Fichaje fichaje) {
-        return null;
+        if (fichaje.getId() == null) {
+            em.persist(fichaje);
+            return fichaje;
+        } else {
+            return em.merge(fichaje);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- correct the `save` method in `FichajeDaoImpl` to actually persist entities instead of returning `null`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413222fe688333b6420204e5288042